### PR TITLE
Larval 5.4 compatibility

### DIFF
--- a/src/ApiMockerController.php
+++ b/src/ApiMockerController.php
@@ -60,7 +60,7 @@ class ApiMockerController extends Controller
         $route = Route::getCurrentRoute();
 
         foreach ($this->endpoints as $path => $config) {
-            if ($path == $route->getPath() && $this->checkRequestMethod()) {
+            if ($path == $route->uri() && $this->checkRequestMethod()) {
                 return $config;
             }
         }


### PR DESCRIPTION
- The getPath method of the Illuminate\Routing\Route class has been removed. You should use the  uri method instead.