### PR TITLE
Allow to change response header

### DIFF
--- a/src/ApiMockerController.php
+++ b/src/ApiMockerController.php
@@ -108,7 +108,13 @@ class ApiMockerController extends Controller
 
         $status = array_get($this->config, 'status', 200);
 
-        return new Response($content, $status, ['Content-Type' => 'application/json']);
+        $header = ['Content-Type' => 'application/json'];
+
+        if (! empty($this->config['header'])) {
+            $header = $this->config['header'];
+        }
+        
+        return new Response($content, $status, $header);
     }
 
 }


### PR DESCRIPTION
@example
instead of only JSON response, allow to add dynamically any header to the response like: ['Content-Type' => 'application/xml']

'api/v1/folders/{id}' => [
            'fixture' => 'path/to/fixture',
            'middleware' => ['auth'],
            'methods' => ['POST'],
            'code' => 200,
            'placeholder' => true,
            'header' => [
                'Content-Type' => 'application/xml'
            ]
        ],