### PR TITLE
Respond with specified code

### DIFF
--- a/src/ApiMockerController.php
+++ b/src/ApiMockerController.php
@@ -106,7 +106,7 @@ class ApiMockerController extends Controller
     {
         $content = $this->getResponseContentFromFixture($this->config['fixture']);
 
-        $status = array_get($this->config, 'status', 200);
+        $status = array_get($this->config, 'code', 200);
 
         return new Response($content, $status, ['Content-Type' => 'application/json']);
     }


### PR DESCRIPTION
As per the documentation and example config the array key `code` should be used instead if `status`